### PR TITLE
Improve StaticConsumer behavior when queue is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 		}
 	},
 	"require": {
+		"php": ">=7.1",
 		"bunny/bunny": "^0.2.4",
 		"symfony/console": "~3.3"
 	}

--- a/src/Console/Command/ConsumerCommand.php
+++ b/src/Console/Command/ConsumerCommand.php
@@ -42,7 +42,7 @@ final class ConsumerCommand extends AbstractConsumerCommand
 		$this->validateSecondsToRun($secondsToLive);
 
 		$consumer = $this->consumerFactory->getConsumer($consumerName);
-		$consumer->consumeForSpecifiedTime($secondsToLive);
+		$consumer->consume($secondsToLive);
 	}
 
 

--- a/src/Console/Command/StaticConsumerCommand.php
+++ b/src/Console/Command/StaticConsumerCommand.php
@@ -42,7 +42,7 @@ final class StaticConsumerCommand extends AbstractConsumerCommand
 		$this->validateAmountOfMessages($amountOfMessages);
 
 		$consumer = $this->consumerFactory->getConsumer($consumerName);
-		$consumer->consumeSpecifiedAmountOfMessages($amountOfMessages);
+		$consumer->consume(null, $amountOfMessages);
 	}
 
 


### PR DESCRIPTION
Current static consumer impl calls consume callback even when queue is empty. This behavior causes _TypeError_ exception when consumer implements _IConsumer_ interface.

```
TypeError: Argument 1 passed to App\Consumer::consume() must be an instance of Bunny\Message, null given in /var/www/project/app/Consumer.php:62
Stack trace:
#0 [internal function]: App\Consumer->consume(NULL)
#1 /var/www/project/vendor/gamee/nette-rabbitmq/src/Consumer/Consumer.php(99): call_user_func(Array, NULL)
#2 /var/www/project/vendor/gamee/nette-rabbitmq/src/Console/Command/StaticConsumerCommand.php(45): Gamee\RabbitMQ\Consumer\Consumer->consumeSpecifiedAmountOfMessages(1)
#3 /var/www/project/vendor/symfony/console/Command/Command.php(264): Gamee\RabbitMQ\Console\Command\StaticConsumerCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /var/www/project/vendor/symfony/console/Application.php(869): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/project/vendor/symfony/console/Application.php(223): Symfony\Component\Console\Application->doRunCommand(Object(Gamee\RabbitMQ\Console\Command\StaticConsumerCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/project/vendor/symfony/console/Application.php(130): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/project/bin/console(5): Symfony\Component\Console\Application->run()
#8 {main}
```