### PR TITLE
DI extension should be loaded using loadConfiguration method

### DIFF
--- a/src/DI/RabbitMQExtension.php
+++ b/src/DI/RabbitMQExtension.php
@@ -74,7 +74,7 @@ final class RabbitMQExtension extends CompilerExtension
 	/**
 	 * @throws \InvalidArgumentException
 	 */
-	public function beforeCompile(): void
+	public function loadConfiguration(): void
 	{
 		$config = $this->validateConfig($this->defaults, $this->getConfig());
 		$builder = $this->getContainerBuilder();


### PR DESCRIPTION
The DI extension should be loaded earlier, otherwise it will not work correctly with other packages. For example with _contributte/console_ package, you have to register this extension before console extension. If you register it later, then console commands are not available.