### PR TITLE
Fixed message publishing to exchanges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 composer.lock
 /vendor
+/tests/Cases/output

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,8 @@
 		"symfony/console": "~3.3 || ^4.0"
 	},
 	"require-dev": {
-		"nette/tester": "^2.0"
+		"nette/tester": "^2.0",
+		"nette/neon": "^2.4",
+		"mockery/mockery": "^1.1"
 	}
 }

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -15,7 +15,7 @@ use Bunny\Client;
 use Bunny\Exception\ClientException;
 use Gamee\RabbitMQ\Connection\Exception\ConnectionException;
 
-final class Connection
+class Connection
 {
 
 	/**

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -15,7 +15,7 @@ use Bunny\Client;
 use Bunny\Exception\ClientException;
 use Gamee\RabbitMQ\Connection\Exception\ConnectionException;
 
-class Connection
+final class Connection implements IConnection
 {
 
 	/**

--- a/src/Connection/ConnectionFactory.php
+++ b/src/Connection/ConnectionFactory.php
@@ -26,7 +26,7 @@ final class ConnectionFactory
 	private $connectionFactory;
 
 	/**
-	 * @var Connection[]
+	 * @var IConnection[]
 	 */
 	private $connections = [];
 
@@ -40,7 +40,7 @@ final class ConnectionFactory
 	/**
 	 * @throws ConnectionFactoryException
 	 */
-	public function getConnection(string $name): Connection
+	public function getConnection(string $name): IConnection
 	{
 		if (!isset($this->connections[$name])) {
 			$this->connections[$name] = $this->create($name);
@@ -53,7 +53,7 @@ final class ConnectionFactory
 	/**
 	 * @throws ConnectionFactoryException
 	 */
-	private function create(string $name): Connection
+	private function create(string $name): IConnection
 	{
 		try {
 			$connectionData = $this->connectionsDataBag->getDataBykey($name);

--- a/src/Connection/IConnection.php
+++ b/src/Connection/IConnection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Connection;
+
+use Bunny\Channel;
+use Bunny\Client;
+use Gamee\RabbitMQ\Connection\Exception\ConnectionException;
+
+interface IConnection
+{
+
+	public function getBunnyClient(): Client;
+
+
+	/**
+	 * @throws ConnectionException
+	 */
+	public function getChannel(): Channel;
+}

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -13,6 +13,7 @@ namespace Gamee\RabbitMQ\Consumer;
 use Bunny\Channel;
 use Bunny\Client;
 use Bunny\Message;
+use Gamee\RabbitMQ\Queue\IQueue;
 use Gamee\RabbitMQ\Queue\Queue;
 
 final class Consumer
@@ -24,7 +25,7 @@ final class Consumer
 	private $name;
 
 	/**
-	 * @var Queue
+	 * @var IQueue
 	 */
 	private $queue;
 
@@ -51,7 +52,7 @@ final class Consumer
 
 	public function __construct(
 		string $name,
-		Queue $queue,
+		IQueue $queue,
 		callable $callback,
 		?int $prefetchSize,
 		?int $prefetchCount
@@ -64,7 +65,7 @@ final class Consumer
 	}
 
 
-	public function getQueue(): Queue
+	public function getQueue(): IQueue
 	{
 		return $this->queue;
 	}

--- a/src/DI/Helpers/ExchangesHelper.php
+++ b/src/DI/Helpers/ExchangesHelper.php
@@ -24,6 +24,7 @@ final class ExchangesHelper extends AbstractHelper
 	 * @var array
 	 */
 	protected $defaults = [
+		'connection' => 'default',
 		'type' => 'direct', // direct/topic/headers/fanout
 		'passive' => false,
 		'durable' => true,

--- a/src/Exchange/Exchange.php
+++ b/src/Exchange/Exchange.php
@@ -12,7 +12,7 @@ namespace Gamee\RabbitMQ\Exchange;
 
 use Gamee\RabbitMQ\Connection\Connection;
 
-final class Exchange
+class Exchange
 {
 
 	/**

--- a/src/Exchange/Exchange.php
+++ b/src/Exchange/Exchange.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\Exchange;
 
-use Gamee\RabbitMQ\Exchange\QueueBinding;
+use Gamee\RabbitMQ\Connection\Connection;
 
 final class Exchange
 {
@@ -60,6 +60,11 @@ final class Exchange
 	 */
 	private $queueBindings;
 
+	/**
+	 * @var Connection
+	 */
+	private $connection;
+
 
 	public function __construct(
 		string $name,
@@ -70,7 +75,8 @@ final class Exchange
 		bool $internal,
 		bool $noWait,
 		array $arguments,
-		array $queueBindings
+		array $queueBindings,
+		Connection $connection
 	) {
 		$this->name = $name;
 		$this->type = $type;
@@ -81,6 +87,7 @@ final class Exchange
 		$this->noWait = $noWait;
 		$this->arguments = $arguments;
 		$this->queueBindings = $queueBindings;
+		$this->connection = $connection;
 	}
 
 
@@ -95,4 +102,9 @@ final class Exchange
 		return $this->queueBindings;
 	}
 
+
+	public function getConnection(): Connection
+	{
+		return $this->connection;
+	}
 }

--- a/src/Exchange/Exchange.php
+++ b/src/Exchange/Exchange.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 namespace Gamee\RabbitMQ\Exchange;
 
 use Gamee\RabbitMQ\Connection\Connection;
+use Gamee\RabbitMQ\Connection\IConnection;
 
-class Exchange
+final class Exchange implements IExchange
 {
 
 	/**
@@ -61,7 +62,7 @@ class Exchange
 	private $queueBindings;
 
 	/**
-	 * @var Connection
+	 * @var IConnection
 	 */
 	private $connection;
 
@@ -76,7 +77,7 @@ class Exchange
 		bool $noWait,
 		array $arguments,
 		array $queueBindings,
-		Connection $connection
+		IConnection $connection
 	) {
 		$this->name = $name;
 		$this->type = $type;
@@ -103,7 +104,7 @@ class Exchange
 	}
 
 
-	public function getConnection(): Connection
+	public function getConnection(): IConnection
 	{
 		return $this->connection;
 	}

--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -34,7 +34,7 @@ final class ExchangeFactory
 	private $connectionFactory;
 
 	/**
-	 * @var Exchange[]
+	 * @var IExchange[]
 	 */
 	private $exchanges;
 
@@ -53,7 +53,7 @@ final class ExchangeFactory
 	/**
 	 * @throws ExchangeFactoryException
 	 */
-	public function getExchange(string $name): Exchange
+	public function getExchange(string $name): IExchange
 	{
 		if (!isset($this->exchanges[$name])) {
 			$this->exchanges[$name] = $this->create($name);
@@ -67,7 +67,7 @@ final class ExchangeFactory
 	 * @throws ExchangeFactoryException
 	 * @throws QueueFactoryException
 	 */
-	private function create(string $name): Exchange
+	private function create(string $name): IExchange
 	{
 		$queueBindings = [];
 

--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -78,24 +78,22 @@ final class ExchangeFactory
 			throw new ExchangeFactoryException("Exchange [$name] does not exist");
 		}
 
+		$connection = $this->connectionFactory->getConnection($exchangeData['connection']);
+
+		$connection->getChannel()->exchangeDeclare(
+			$name,
+			$exchangeData['type'],
+			$exchangeData['passive'],
+			$exchangeData['durable'],
+			$exchangeData['autoDelete'],
+			$exchangeData['internal'],
+			$exchangeData['noWait'],
+			$exchangeData['arguments']
+		);
+
 		if (!empty($exchangeData['queueBindings'])) {
 			foreach ($exchangeData['queueBindings'] as $queueName => $queueBinding) {
 				$queue = $this->queueFactory->getQueue($queueName); // (QueueFactoryException)
-				$connection = $queue->getConnection();
-
-				/**
-				 * Declare the actual queue
-				 */
-				$connection->getChannel()->exchangeDeclare(
-					$name,
-					$exchangeData['type'],
-					$exchangeData['passive'],
-					$exchangeData['durable'],
-					$exchangeData['autoDelete'],
-					$exchangeData['internal'],
-					$exchangeData['noWait'],
-					$exchangeData['arguments']
-				);
 
 				/**
 				 * Create binding to the queue
@@ -115,13 +113,6 @@ final class ExchangeFactory
 					$queueBinding['arguments']
 				);
 			}
-		} else {
-			/**
-			 * @todo Throw an exception or not?
-			 */
-			throw new ExchangeFactoryException(
-				"Exchange [$name] could not be created, it is not bound to any queue"
-			);
 		}
 
 		return new Exchange(
@@ -133,7 +124,8 @@ final class ExchangeFactory
 			$exchangeData['internal'],
 			$exchangeData['noWait'],
 			$exchangeData['arguments'],
-			$queueBindings
+			$queueBindings,
+			$connection
 		);
 	}
 

--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -12,6 +12,7 @@ namespace Gamee\RabbitMQ\Exchange;
 
 use Gamee\RabbitMQ\Connection\ConnectionFactory;
 use Gamee\RabbitMQ\Exchange\Exception\ExchangeFactoryException;
+use Gamee\RabbitMQ\Queue\Exception\QueueFactoryException;
 use Gamee\RabbitMQ\Queue\QueueFactory;
 
 final class ExchangeFactory

--- a/src/Exchange/IExchange.php
+++ b/src/Exchange/IExchange.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Exchange;
+
+use Gamee\RabbitMQ\Connection\IConnection;
+
+interface IExchange
+{
+
+	public function getName(): string;
+
+
+	public function getQueueBindings(): array;
+
+
+	public function getConnection(): IConnection;
+}

--- a/src/Exchange/QueueBinding.php
+++ b/src/Exchange/QueueBinding.php
@@ -10,13 +10,14 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\Exchange;
 
+use Gamee\RabbitMQ\Queue\IQueue;
 use Gamee\RabbitMQ\Queue\Queue;
 
 final class QueueBinding
 {
 
 	/**
-	 * @var Queue
+	 * @var IQueue
 	 */
 	private $queue;
 
@@ -37,7 +38,7 @@ final class QueueBinding
 
 
 	public function __construct(
-		Queue $queue,
+		IQueue $queue,
 		string $routingKey,
 		bool $noWait,
 		array $arguments
@@ -49,7 +50,7 @@ final class QueueBinding
 	}
 
 
-	public function getQueue(): Queue
+	public function getQueue(): IQueue
 	{
 		return $this->queue;
 	}

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace Gamee\RabbitMQ\Producer;
 
 use Gamee\RabbitMQ\Exchange\Exchange;
+use Gamee\RabbitMQ\Exchange\IExchange;
+use Gamee\RabbitMQ\Queue\IQueue;
 use Gamee\RabbitMQ\Queue\Queue;
 
 final class Producer
@@ -20,12 +22,12 @@ final class Producer
 	public const DELIVERY_MODE_PERSISTENT = 2;
 
 	/**
-	 * @var Exchange|NULL
+	 * @var IExchange|NULL
 	 */
 	private $exchange;
 
 	/**
-	 * @var Queue|NULL
+	 * @var IQueue|NULL
 	 */
 	private $queue;
 
@@ -41,8 +43,8 @@ final class Producer
 
 
 	public function __construct(
-		Exchange $exchange = null,
-		Queue $queue = null,
+		IExchange $exchange = null,
+		IQueue $queue = null,
 		string $contentType,
 		int $deliveryMode
 	) {

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -53,7 +53,7 @@ final class Producer
 	}
 
 
-	public function publish(string $message, array $headers = []): void
+	public function publish(string $message, array $headers = [], ?string $routingKey = null): void
 	{
 		$headers = array_merge($this->getBasicHeaders(), $headers);
 
@@ -62,7 +62,7 @@ final class Producer
 		}
 
 		if ($this->exchange) {
-			$this->publishToExchange($message, $headers);
+			$this->publishToExchange($message, $headers, $routingKey ?? '');
 		}
 	}
 
@@ -87,16 +87,14 @@ final class Producer
 	}
 
 
-	private function publishToExchange(string $message, array $headers = []): void
+	private function publishToExchange(string $message, array $headers = [], string $routingKey): void
 	{
-		foreach ($this->exchange->getQueueBindings() as $queueBinding) {
-			$queueBinding->getQueue()->getConnection()->getChannel()->publish(
-				$message,
-				$headers,
-				$this->exchange->getName(),
-				$queueBinding->getRoutingKey()
-			);
-		}
+		$this->exchange->getConnection()->getChannel()->publish(
+			$message,
+			$headers,
+			$this->exchange->getName(),
+			$routingKey
+		);
 	}
 
 }

--- a/src/Queue/IQueue.php
+++ b/src/Queue/IQueue.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Queue;
+
+use Gamee\RabbitMQ\Connection\IConnection;
+
+interface IQueue
+{
+
+	public function getName(): string;
+
+
+	public function getConnection(): IConnection;
+}

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -12,7 +12,7 @@ namespace Gamee\RabbitMQ\Queue;
 
 use Gamee\RabbitMQ\Connection\Connection;
 
-final class Queue
+class Queue
 {
 
 	/**

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 namespace Gamee\RabbitMQ\Queue;
 
 use Gamee\RabbitMQ\Connection\Connection;
+use Gamee\RabbitMQ\Connection\IConnection;
 
-class Queue
+final class Queue implements IQueue
 {
 
 	/**
@@ -21,7 +22,7 @@ class Queue
 	private $name;
 
 	/**
-	 * @var Connection
+	 * @var IConnection
 	 */
 	private $connection;
 
@@ -58,7 +59,7 @@ class Queue
 
 	public function __construct(
 		string $name,
-		Connection $connection,
+		IConnection $connection,
 		bool $passive,
 		bool $durable,
 		bool $exclusive,
@@ -83,7 +84,7 @@ class Queue
 	}
 
 
-	public function getConnection(): Connection
+	public function getConnection(): IConnection
 	{
 		return $this->connection;
 	}

--- a/src/Queue/QueueFactory.php
+++ b/src/Queue/QueueFactory.php
@@ -28,7 +28,7 @@ final class QueueFactory
 	private $connectionFactory;
 
 	/**
-	 * @var Queue[]
+	 * @var IQueue[]
 	 */
 	private $queues;
 
@@ -43,7 +43,7 @@ final class QueueFactory
 	/**
 	 * @throws QueueFactoryException
 	 */
-	public function getQueue(string $name): Queue
+	public function getQueue(string $name): IQueue
 	{
 		if (!isset($this->queues[$name])) {
 			$this->queues[$name] = $this->create($name);
@@ -57,7 +57,7 @@ final class QueueFactory
 	 * @throws QueueFactoryException
 	 * @throws ConnectionFactoryException
 	 */
-	private function create(string $name): Queue
+	private function create(string $name): IQueue
 	{
 		try {
 			$queueData = $this->queuesDataBag->getDataBykey($name);

--- a/tests/Cases/ProducerTest.phpt
+++ b/tests/Cases/ProducerTest.phpt
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Tests\Cases;
+
+use Gamee\RabbitMQ\Connection\Connection;
+use Gamee\RabbitMQ\Exchange\Exchange;
+use Gamee\RabbitMQ\Producer\Producer;
+use Gamee\RabbitMQ\Queue\Queue;
+use Gamee\RabbitMQ\Tests\Mocks\ChannelMock;
+use Gamee\RabbitMQ\Tests\Mocks\Helper\RabbitMQMessageHelper;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+final class ProducerTest extends TestCase
+{
+
+	public function testQueue()
+	{
+		$testQueueName = 'testQueue';
+
+		$producer = $this->createQueueProducer($testQueueName);
+
+		$messageHelper = RabbitMQMessageHelper::getInstance();
+		$messageHelper->reinit();
+
+		$producer->publish('test');
+
+		$testQueueMessages = $messageHelper->getQueueMessages($testQueueName);
+
+		Assert::same(
+			[
+				[
+					'body' => 'test',
+					'headers' => [
+						'content-type' => 'application/json',
+						'delivery-mode' => 2,
+					],
+				],
+			],
+			$testQueueMessages
+		);
+	}
+
+
+	public function testDirectExchange()
+	{
+		$exchangeName = 'testDirectExchange';
+		$producer = $this->createExchangeProducer($exchangeName);
+		$messageHelper = RabbitMQMessageHelper::getInstance();
+		$messageHelper->reinit();
+
+		$routingKey = 'non-existent-routing-key';
+		$producer->publish('should not appear anywhere', [], $routingKey);
+
+		Assert::same([], $messageHelper->getQueueMessages());
+
+		/**************************************************************************************************************/
+
+		$routingKey = 'test-queue-direct-exchange';
+		$producer->publish('should appear in one queue', [], $routingKey);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear in one queue',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+
+		/**************************************************************************************************************/
+
+		$routingKey = 'test-queue-direct-exchange';
+		$producer->publish('should appear in one queue 2', [], $routingKey);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear in one queue',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear in one queue 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+
+		/**************************************************************************************************************/
+
+		$routingKey = 'non-existent-routing-key';
+		$producer->publish('should not appear anywhere', [], $routingKey);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear in one queue',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear in one queue 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+
+		/**************************************************************************************************************/
+
+		$routingKey = 'test-queue-direct-routing-key1';
+		$producer->publish('should appear in 2 queues', [], $routingKey);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear in one queue',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear in one queue 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+				'testQueueRK1' => [
+					[
+						'body' => 'should appear in 2 queues',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+				'testQueueRK2' => [
+					[
+						'body' => 'should appear in 2 queues',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+	}
+
+
+	public function testFanoutExchange()
+	{
+		$exchangeName = 'testFanoutExchange';
+		$producer = $this->createExchangeProducer($exchangeName);
+		$messageHelper = RabbitMQMessageHelper::getInstance();
+		$messageHelper->reinit();
+
+		$routingKey = 'non-existent-routing-key';
+		$producer->publish('should appear everywhere', [], $routingKey);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+				'testQueueRK1' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+				'testQueueRK2' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+
+		$routingKey = '';
+		$producer->publish(
+			'should appear everywhere 2',
+			[
+				'extra-header' => 1,
+			],
+			$routingKey
+		);
+
+		Assert::same(
+			[
+				'testQueue' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear everywhere 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+							'extra-header' => 1,
+						],
+					],
+				],
+				'testQueueRK1' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear everywhere 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+							'extra-header' => 1,
+						],
+					],
+				],
+				'testQueueRK2' => [
+					[
+						'body' => 'should appear everywhere',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+						],
+					],
+					[
+						'body' => 'should appear everywhere 2',
+						'headers' => [
+							'content-type' => 'application/json',
+							'delivery-mode' => 2,
+							'extra-header' => 1,
+						],
+					],
+				],
+			],
+			$messageHelper->getQueueMessages()
+		);
+	}
+
+
+	private function createQueueProducer(string $testQueueName): Producer
+	{
+		$channelMock = new ChannelMock();
+
+		$connectionMock = \Mockery::mock(Connection::class)
+			->shouldReceive('getChannel')->andReturn($channelMock)->getMock()
+		;
+
+		$queueMock = \Mockery::mock(Queue::class)
+			->shouldReceive('getConnection')->andReturn($connectionMock)->getMock()
+			->shouldReceive('getName')->andReturn($testQueueName)->getMock()
+		;
+
+		$producer = new Producer(
+			null,
+			$queueMock,
+			'application/json',
+			2
+		);
+
+		return $producer;
+	}
+
+
+	private function createExchangeProducer(string $testExchange): Producer
+	{
+		$channelMock = new ChannelMock();
+
+		$connectionMock = \Mockery::mock(Connection::class)
+			->shouldReceive('getChannel')->andReturn($channelMock)->getMock()
+		;
+
+		$exchangeMock = \Mockery::mock(Exchange::class)
+			->shouldReceive('getConnection')->andReturn($connectionMock)->getMock()
+			->shouldReceive('getName')->andReturn($testExchange)->getMock()
+		;
+
+		$producer = new Producer(
+			$exchangeMock,
+			null,
+			'application/json',
+			2
+		);
+
+		return $producer;
+	}
+
+}
+
+(new ProducerTest())->run();

--- a/tests/Cases/ProducerTest.phpt
+++ b/tests/Cases/ProducerTest.phpt
@@ -18,7 +18,7 @@ require __DIR__ . '/../bootstrap.php';
 final class ProducerTest extends TestCase
 {
 
-	public function testQueue()
+	public function testQueue(): void
 	{
 		$testQueueName = 'testQueue';
 
@@ -46,7 +46,7 @@ final class ProducerTest extends TestCase
 	}
 
 
-	public function testDirectExchange()
+	public function testDirectExchange(): void
 	{
 		$exchangeName = 'testDirectExchange';
 		$producer = $this->createExchangeProducer($exchangeName);
@@ -179,7 +179,7 @@ final class ProducerTest extends TestCase
 	}
 
 
-	public function testFanoutExchange()
+	public function testFanoutExchange(): void
 	{
 		$exchangeName = 'testFanoutExchange';
 		$producer = $this->createExchangeProducer($exchangeName);

--- a/tests/Cases/ProducerTest.phpt
+++ b/tests/Cases/ProducerTest.phpt
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\Tests\Cases;
 
-use Gamee\RabbitMQ\Connection\Connection;
-use Gamee\RabbitMQ\Exchange\Exchange;
+use Gamee\RabbitMQ\Connection\IConnection;
+use Gamee\RabbitMQ\Exchange\IExchange;
 use Gamee\RabbitMQ\Producer\Producer;
-use Gamee\RabbitMQ\Queue\Queue;
+use Gamee\RabbitMQ\Queue\IQueue;
 use Gamee\RabbitMQ\Tests\Mocks\ChannelMock;
 use Gamee\RabbitMQ\Tests\Mocks\Helper\RabbitMQMessageHelper;
 use Tester\Assert;
@@ -294,11 +294,11 @@ final class ProducerTest extends TestCase
 	{
 		$channelMock = new ChannelMock();
 
-		$connectionMock = \Mockery::mock(Connection::class)
+		$connectionMock = \Mockery::mock(IConnection::class)
 			->shouldReceive('getChannel')->andReturn($channelMock)->getMock()
 		;
 
-		$queueMock = \Mockery::mock(Queue::class)
+		$queueMock = \Mockery::mock(IQueue::class)
 			->shouldReceive('getConnection')->andReturn($connectionMock)->getMock()
 			->shouldReceive('getName')->andReturn($testQueueName)->getMock()
 		;
@@ -318,11 +318,11 @@ final class ProducerTest extends TestCase
 	{
 		$channelMock = new ChannelMock();
 
-		$connectionMock = \Mockery::mock(Connection::class)
+		$connectionMock = \Mockery::mock(IConnection::class)
 			->shouldReceive('getChannel')->andReturn($channelMock)->getMock()
 		;
 
-		$exchangeMock = \Mockery::mock(Exchange::class)
+		$exchangeMock = \Mockery::mock(IExchange::class)
 			->shouldReceive('getConnection')->andReturn($connectionMock)->getMock()
 			->shouldReceive('getName')->andReturn($testExchange)->getMock()
 		;

--- a/tests/Mocks/ChannelMock.php
+++ b/tests/Mocks/ChannelMock.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Tests\Mocks;
+
+use Bunny\Channel;
+use Gamee\RabbitMQ\Tests\Mocks\Helper\RabbitMQMessageHelper;
+use Nette\Neon\Neon;
+
+final class ChannelMock extends Channel
+{
+
+	/**
+	 * @var RabbitMQMessageHelper
+	 */
+	private $messageHelper;
+
+
+	public function __construct()
+	{
+		$config = Neon::decode(file_get_contents(__DIR__ . '/../config/config.test.neon'));
+
+		$this->messageHelper = RabbitMQMessageHelper::getInstance($config['rabbitmq']);
+	}
+
+
+	public function publish(
+		$body,
+		array $headers = [],
+		$exchange = '',
+		$routingKey = '',
+		$mandatory = false,
+		$immediate = false
+	)
+	{
+		if ($exchange === '') {
+			$this->messageHelper->publishToQueueDirectly($routingKey, $body, $headers);
+		} else {
+			$this->messageHelper->publishToExchange($exchange, $body, $headers, $routingKey);
+		}
+	}
+
+}

--- a/tests/Mocks/Helper/RabbitMQMessageHelper.php
+++ b/tests/Mocks/Helper/RabbitMQMessageHelper.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Tests\Mocks\Helper;
+
+final class RabbitMQMessageHelper
+{
+
+	/**
+	 * @var RabbitMQMessageHelper
+	 */
+	private static $self;
+
+	/**
+	 * @var string[][]
+	 */
+	private $queueMessages = [];
+
+	/**
+	 * @var array
+	 */
+	private $config;
+
+
+	private function __construct(array $config)
+	{
+		self::$self = $this;
+		$this->config = $config;
+	}
+
+
+	public static function getInstance(array $config = null): self
+	{
+		if (self::$self === null) {
+			if ($config === null) {
+				throw new \Exception('Missing config');
+			}
+			self::$self = new RabbitMQMessageHelper($config);
+		}
+
+		return self::$self;
+	}
+
+
+	public function reinit(): void
+	{
+		$this->queueMessages = [];
+	}
+
+	public function publishToQueueDirectly(
+		string $queueName,
+		string $body,
+		array $headers = []
+	): void
+	{
+		$this->queueMessages[$queueName][] = [
+			'body' => $body,
+			'headers' => $headers,
+		];
+	}
+
+
+	public function publishToExchange(
+		string $exchangeName,
+		string $body,
+		array $headers,
+		string $routingKey
+	): void
+	{
+		$exchangeConfig = $this->config['exchanges'][$exchangeName];
+		switch ($exchangeConfig['type']) {
+			case 'fanout':
+				$this->publishFanoutMessage($exchangeConfig, $body, $headers);
+				break;
+
+			case 'direct':
+				$this->publishDirectMessage($exchangeConfig, $body, $headers, $routingKey);
+				break;
+
+			case 'headers':
+				$this->publishHeadersMessage($exchangeConfig, $body, $headers);
+				break;
+
+			case 'topic':
+				$this->publishTopicMessage($exchangeConfig, $body, $headers, $routingKey);
+				break;
+
+		}
+
+	}
+
+
+	public function getQueueMessages(string $queueName = null): array
+	{
+		if ($queueName === null) {
+			$messages = $this->queueMessages;
+		} else {
+			$messages = $this->queueMessages[$queueName] ?? [];
+		}
+
+		return $messages;
+	}
+
+
+	private function publishFanoutMessage(
+		array $exchangeConfig,
+		string $body,
+		array $headers
+	): void
+	{
+		foreach ($exchangeConfig['queueBindings'] as $queueName => $queueBinding) {
+			$this->publishToQueueDirectly($queueName, $body, $headers);
+		}
+	}
+
+
+	private function publishDirectMessage(
+		array $exchangeConfig,
+		string $body,
+		array $headers,
+		string $routingKey
+	): void
+	{
+		foreach ($exchangeConfig['queueBindings'] as $queueName => $queueBinding) {
+			if ($queueBinding['routingKey'] === $routingKey) {
+				$this->publishToQueueDirectly($queueName, $body, $headers);
+			}
+		}
+	}
+
+
+	private function publishHeadersMessage(
+		array $exchangeConfig,
+		string $body,
+		array $headers
+	)
+	{
+		throw new \LogicException('Not implemented');
+	}
+
+
+	private function publishTopicMessage(
+		array $exchangeConfig,
+		string $body,
+		array $headers,
+		string $routingKey
+	)
+	{
+		throw new \LogicException('Not implemented');
+	}
+
+}

--- a/tests/config/config.test.neon
+++ b/tests/config/config.test.neon
@@ -1,0 +1,25 @@
+rabbitmq:
+	exchanges:
+		testDirectExchange:
+			type: direct
+			queueBindings:
+				testQueue:
+					routingKey: test-queue-direct-exchange
+				testQueueRK1:
+					routingKey: test-queue-direct-routing-key1
+				testQueueRK2:
+					routingKey: test-queue-direct-routing-key1
+
+		testFanoutExchange:
+			type: fanout
+			queueBindings:
+				testQueue:
+					routingKey: test-queue-direct-exchange
+				testQueueRK1:
+					routingKey: test-queue-direct-routing-key1
+				testQueueRK2:
+					routingKey: test-queue-direct-routing-key1
+
+	queues:
+		testQueue:
+			connection: testConnection


### PR DESCRIPTION
Messages were published to exchanges incorrectly. A message was published for each bound queue instead of just once.

Also routing key was used incorrectly. Routing key belongs to published message, exchange then decides what to do with the message based on the routing key. Before this, message was published for each bound queue with routing key of the queue's name.