### PR TITLE
Resolve #15 - autoCreate: false queues and exchanges by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ rabbitmq:
 	queues:
 		testQueue:
 			connection: default
-			autoCreate: true
+			# force queue declare on first queue operation during request
+			# autoCreate: true 
 
 	exchanges:
 		testExchange:
@@ -49,7 +50,8 @@ rabbitmq:
 			queueBindings:
 				testQueue:
 					routingKey: testRoutingKey
-			autoCreate: true
+			# force exchange declare on first exchange operation during request
+			# autoCreate: true
 
 	producers:
 		testProducer:
@@ -67,9 +69,24 @@ rabbitmq:
 				prefetchCount: 5
 ```
 
-### Publishing messages
+### Declaring Queues and Exchanges
 
-Note: Queue will be created automatically after publishing first message. 
+Since v3.0, all queues and exchanges are by default declared on demand using the console command: 
+
+```
+php index.php rabbitmq:declareQueuesAndExchanges
+```
+
+It's intended to be a part of the deploy process to make sure all the queues and exchanges are prepared for use.
+
+If you need to override this behavior (for example only declare queues that are used during a request and nothing else), 
+just add the `autoCreate: true` parameter to queue or exchange of your choice.
+
+You may also want to declare the queues and exchanges via rabbitmq management interface or a script but if you fail to 
+do so, don't run the declare console command and don't specify `autoCreate: true`, exceptions will be thrown 
+when accessing undeclared queues/exchanges.
+
+### Publishing messages
 
 services.neon:
 

--- a/src/AbstractDataBag.php
+++ b/src/AbstractDataBag.php
@@ -35,7 +35,7 @@ abstract class AbstractDataBag
 	}
 
 
-	public function getDatakeys(): array
+	public function getDataKeys(): array
 	{
 		return array_keys($this->data);
 	}

--- a/src/Console/Command/AbstractConsumerCommand.php
+++ b/src/Console/Command/AbstractConsumerCommand.php
@@ -52,7 +52,7 @@ abstract class AbstractConsumerCommand extends Command
 					"Consumer [$consumerName] does not exist. \n\n Available consumers: %s",
 					implode('', array_map(function($s) {
 						return "\n\t- [{$s}]";
-					}, $this->consumersDataBag->getDatakeys()))
+					}, $this->consumersDataBag->getDataKeys()))
 				)
 			);
 		}

--- a/src/Console/Command/DeclareQueuesAndExchangesCommand.php
+++ b/src/Console/Command/DeclareQueuesAndExchangesCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\Console\Command;
 
-use Gamee\RabbitMQ\Exchange\ExchangeFactory;
+use Gamee\RabbitMQ\Exchange\ExchangeDeclarator;
 use Gamee\RabbitMQ\Exchange\ExchangesDataBag;
-use Gamee\RabbitMQ\Queue\QueueFactory;
+use Gamee\RabbitMQ\Queue\QueueDeclarator;
 use Gamee\RabbitMQ\Queue\QueuesDataBag;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,28 +28,28 @@ final class DeclareQueuesAndExchangesCommand extends Command
 	private $exchangesDataBag;
 
 	/**
-	 * @var QueueFactory
+	 * @var QueueDeclarator
 	 */
-	private $queueFactory;
+	private $queueDeclarator;
 
 	/**
-	 * @var ExchangeFactory
+	 * @var ExchangeDeclarator
 	 */
-	private $exchangeFactory;
+	private $exchangeDeclarator;
 
 
 	public function __construct(
 		QueuesDataBag $queuesDataBag,
-		QueueFactory $queueFactory,
+		QueueDeclarator $queueDeclarator,
 		ExchangesDataBag $exchangesDataBag,
-		ExchangeFactory $exchangeFactory
+		ExchangeDeclarator $exchangeDeclarator
 	)
 	{
 		parent::__construct(self::COMMAND_NAME);
 		$this->queuesDataBag = $queuesDataBag;
 		$this->exchangesDataBag = $exchangesDataBag;
-		$this->queueFactory = $queueFactory;
-		$this->exchangeFactory = $exchangeFactory;
+		$this->queueDeclarator = $queueDeclarator;
+		$this->exchangeDeclarator = $exchangeDeclarator;
 	}
 
 
@@ -61,12 +61,12 @@ final class DeclareQueuesAndExchangesCommand extends Command
 	}
 
 
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function execute(InputInterface $input, OutputInterface $output): void
 	{
 		$output->writeln('<info>Declaring queues:</info>');
 		foreach ($this->queuesDataBag->getDataKeys() as $queueName) {
 			$output->writeln($queueName);
-			$this->queueFactory->getQueue($queueName, true);
+			$this->queueDeclarator->declareQueue($queueName);
 		}
 
 		$output->writeln('');
@@ -74,7 +74,7 @@ final class DeclareQueuesAndExchangesCommand extends Command
 		$output->writeln('<info>Declaring exchanges:</info>');
 		foreach ($this->exchangesDataBag->getDataKeys() as $exchangeName) {
 			$output->writeln($exchangeName);
-			$this->exchangeFactory->getExchange($exchangeName, true);
+			$this->exchangeDeclarator->declareExchange($exchangeName);
 		}
 
 		$output->writeln('');

--- a/src/Console/Command/DeclareQueuesAndExchangesCommand.php
+++ b/src/Console/Command/DeclareQueuesAndExchangesCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Console\Command;
+
+use Gamee\RabbitMQ\Exchange\ExchangeFactory;
+use Gamee\RabbitMQ\Exchange\ExchangesDataBag;
+use Gamee\RabbitMQ\Queue\QueueFactory;
+use Gamee\RabbitMQ\Queue\QueuesDataBag;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class DeclareQueuesAndExchangesCommand extends Command
+{
+
+	private const COMMAND_NAME = 'rabbitmq:declareQueuesAndExchanges';
+
+	/**
+	 * @var QueuesDataBag
+	 */
+	private $queuesDataBag;
+
+	/**
+	 * @var ExchangesDataBag
+	 */
+	private $exchangesDataBag;
+
+	/**
+	 * @var QueueFactory
+	 */
+	private $queueFactory;
+
+	/**
+	 * @var ExchangeFactory
+	 */
+	private $exchangeFactory;
+
+
+	public function __construct(
+		QueuesDataBag $queuesDataBag,
+		QueueFactory $queueFactory,
+		ExchangesDataBag $exchangesDataBag,
+		ExchangeFactory $exchangeFactory
+	)
+	{
+		parent::__construct(self::COMMAND_NAME);
+		$this->queuesDataBag = $queuesDataBag;
+		$this->exchangesDataBag = $exchangesDataBag;
+		$this->queueFactory = $queueFactory;
+		$this->exchangeFactory = $exchangeFactory;
+	}
+
+
+	protected function configure(): void
+	{
+		$this->setDescription(
+			'Creates all queues and exchanges defined in configs. Intended to run during deploy process'
+		);
+	}
+
+
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$output->writeln('<info>Declaring queues:</info>');
+		foreach ($this->queuesDataBag->getDataKeys() as $queueName) {
+			$output->writeln($queueName);
+			$this->queueFactory->getQueue($queueName, true);
+		}
+
+		$output->writeln('');
+
+		$output->writeln('<info>Declaring exchanges:</info>');
+		foreach ($this->exchangesDataBag->getDataKeys() as $exchangeName) {
+			$output->writeln($exchangeName);
+			$this->exchangeFactory->getExchange($exchangeName, true);
+		}
+
+		$output->writeln('');
+		$output->writeln('<info>Declarations done!</info>');
+	}
+
+}

--- a/src/DI/Helpers/ExchangesHelper.php
+++ b/src/DI/Helpers/ExchangesHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\DI\Helpers;
 
+use Gamee\RabbitMQ\Exchange\ExchangeDeclarator;
 use Gamee\RabbitMQ\Exchange\ExchangeFactory;
 use Gamee\RabbitMQ\Exchange\ExchangesDataBag;
 use Nette\DI\ContainerBuilder;
@@ -85,6 +86,9 @@ final class ExchangesHelper extends AbstractHelper
 		$exchangesDataBag = $builder->addDefinition($this->extension->prefix('exchangesDataBag'))
 			->setFactory(ExchangesDataBag::class)
 			->setArguments([$exchangesConfig]);
+
+		$builder->addDefinition($this->extension->prefix('exchangesDeclarator'))
+			->setFactory(ExchangeDeclarator::class);
 
 		return $builder->addDefinition($this->extension->prefix('exchangeFactory'))
 			->setFactory(ExchangeFactory::class)

--- a/src/DI/Helpers/ExchangesHelper.php
+++ b/src/DI/Helpers/ExchangesHelper.php
@@ -33,7 +33,7 @@ final class ExchangesHelper extends AbstractHelper
 		'noWait' => false,
 		'arguments' => [],
 		'queueBindings' => [], // See self::$queueBindingDefaults
-		'autoCreate' => true,
+		'autoCreate' => false,
 	];
 
 	/**

--- a/src/DI/Helpers/QueuesHelper.php
+++ b/src/DI/Helpers/QueuesHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Gamee\RabbitMQ\DI\Helpers;
 
+use Gamee\RabbitMQ\Queue\QueueDeclarator;
 use Gamee\RabbitMQ\Queue\QueueFactory;
 use Gamee\RabbitMQ\Queue\QueuesDataBag;
 use Nette\DI\ContainerBuilder;
@@ -47,6 +48,9 @@ final class QueuesHelper extends AbstractHelper
 		$queuesDataBag = $builder->addDefinition($this->extension->prefix('queuesDataBag'))
 			->setFactory(QueuesDataBag::class)
 			->setArguments([$queuesConfig]);
+
+		$builder->addDefinition($this->extension->prefix('queueDeclarator'))
+			->setFactory(QueueDeclarator::class);
 
 		return $builder->addDefinition($this->extension->prefix('queueFactory'))
 			->setFactory(QueueFactory::class)

--- a/src/DI/Helpers/QueuesHelper.php
+++ b/src/DI/Helpers/QueuesHelper.php
@@ -29,7 +29,7 @@ final class QueuesHelper extends AbstractHelper
 		'autoDelete' => false,
 		'noWait' => false,
 		'arguments' => [],
-		'autoCreate' => true,
+		'autoCreate' => false,
 	];
 
 

--- a/src/DI/RabbitMQExtension.php
+++ b/src/DI/RabbitMQExtension.php
@@ -12,6 +12,7 @@ namespace Gamee\RabbitMQ\DI;
 
 use Gamee\RabbitMQ\Client;
 use Gamee\RabbitMQ\Console\Command\ConsumerCommand;
+use Gamee\RabbitMQ\Console\Command\DeclareQueuesAndExchangesCommand;
 use Gamee\RabbitMQ\Console\Command\StaticConsumerCommand;
 use Gamee\RabbitMQ\DI\Helpers\ConnectionsHelper;
 use Gamee\RabbitMQ\DI\Helpers\ConsumersHelper;
@@ -129,9 +130,13 @@ final class RabbitMQExtension extends CompilerExtension
 		$staticConsumerCommand = $builder->addDefinition($this->prefix('console.staticConsumerCommand'))
 			->setFactory(StaticConsumerCommand::class);
 
+		$queuesExchangesCommand = $builder->addDefinition($this->prefix('console.declareQueuesExchangesCommand'))
+			->setFactory(DeclareQueuesAndExchangesCommand::class);
+
 		if (class_exists('Kdyby\Console\DI\ConsoleExtension')) {
 			$consumerCommand->addTag(\Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND);
 			$staticConsumerCommand->addTag(\Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND);
+			$queuesExchangesCommand->addTag(\Kdyby\Console\DI\ConsoleExtension::TAG_COMMAND);
 		}
 	}
 

--- a/src/Exchange/ExchangeDeclarator.php
+++ b/src/Exchange/ExchangeDeclarator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Exchange;
+
+use Gamee\RabbitMQ\Connection\ConnectionFactory;
+use Gamee\RabbitMQ\Exchange\Exception\ExchangeFactoryException;
+use Gamee\RabbitMQ\Queue\QueueFactory;
+
+final class ExchangeDeclarator
+{
+
+	/**
+	 * @var ConnectionFactory
+	 */
+	private $connectionFactory;
+
+	/**
+	 * @var ExchangesDataBag
+	 */
+	private $exchangesDataBag;
+
+	/**
+	 * @var QueueFactory
+	 */
+	private $queueFactory;
+
+
+	public function __construct(
+		ConnectionFactory $connectionFactory,
+		ExchangesDataBag $exchangesDataBag,
+		QueueFactory $queueFactory
+	)
+	{
+		$this->connectionFactory = $connectionFactory;
+		$this->exchangesDataBag = $exchangesDataBag;
+		$this->queueFactory = $queueFactory;
+	}
+
+
+	public function declareExchange(string $name): void
+	{
+		try {
+			$exchangeData = $this->exchangesDataBag->getDataBykey($name);
+		} catch (\InvalidArgumentException $e) {
+			throw new ExchangeFactoryException("Exchange [$name] does not exist");
+		}
+
+		$connection = $this->connectionFactory->getConnection($exchangeData['connection']);
+
+		$connection->getChannel()->exchangeDeclare(
+			$name,
+			$exchangeData['type'],
+			$exchangeData['passive'],
+			$exchangeData['durable'],
+			$exchangeData['autoDelete'],
+			$exchangeData['internal'],
+			$exchangeData['noWait'],
+			$exchangeData['arguments']
+		);
+
+		if (!empty($exchangeData['queueBindings'])) {
+			foreach ($exchangeData['queueBindings'] as $queueName => $queueBinding) {
+				$queue = $this->queueFactory->getQueue($queueName);
+
+				$connection->getChannel()->queueBind(
+					$queue->getName(),
+					$name,
+					$queueBinding['routingKey'],
+					$queueBinding['noWait'],
+					$queueBinding['arguments']
+				);
+			}
+		}
+	}
+
+}

--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -43,7 +43,8 @@ final class ExchangeFactory
 		ExchangesDataBag $exchangesDataBag,
 		QueueFactory $queueFactory,
 		ConnectionFactory $connectionFactory
-	) {
+	)
+	{
 		$this->exchangesDataBag = $exchangesDataBag;
 		$this->queueFactory = $queueFactory;
 		$this->connectionFactory = $connectionFactory;
@@ -53,10 +54,10 @@ final class ExchangeFactory
 	/**
 	 * @throws ExchangeFactoryException
 	 */
-	public function getExchange(string $name): IExchange
+	public function getExchange(string $name, bool $forceDeclare = false): IExchange
 	{
-		if (!isset($this->exchanges[$name])) {
-			$this->exchanges[$name] = $this->create($name);
+		if ($forceDeclare || !isset($this->exchanges[$name])) {
+			$this->exchanges[$name] = $this->create($name, $forceDeclare);
 		}
 
 		return $this->exchanges[$name];
@@ -67,7 +68,7 @@ final class ExchangeFactory
 	 * @throws ExchangeFactoryException
 	 * @throws QueueFactoryException
 	 */
-	private function create(string $name): IExchange
+	private function create(string $name, bool $forceDeclare): IExchange
 	{
 		$queueBindings = [];
 
@@ -81,7 +82,7 @@ final class ExchangeFactory
 
 		$connection = $this->connectionFactory->getConnection($exchangeData['connection']);
 
-		if ($exchangeData['autoCreate']) {
+		if ($forceDeclare || $exchangeData['autoCreate']) {
 			$connection->getChannel()->exchangeDeclare(
 				$name,
 				$exchangeData['type'],
@@ -98,7 +99,7 @@ final class ExchangeFactory
 			foreach ($exchangeData['queueBindings'] as $queueName => $queueBinding) {
 				$queue = $this->queueFactory->getQueue($queueName); // (QueueFactoryException)
 
-				if ($exchangeData['autoCreate']) {
+				if ($forceDeclare || $exchangeData['autoCreate']) {
 					/**
 					 * Create binding to the queue
 					 */

--- a/src/Queue/QueueDeclarator.php
+++ b/src/Queue/QueueDeclarator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamee\RabbitMQ\Queue;
+
+use Gamee\RabbitMQ\Connection\ConnectionFactory;
+use Gamee\RabbitMQ\Queue\Exception\QueueFactoryException;
+
+final class QueueDeclarator
+{
+
+	/**
+	 * @var QueuesDataBag
+	 */
+	private $queuesDataBag;
+
+	/**
+	 * @var ConnectionFactory
+	 */
+	private $connectionFactory;
+
+
+	public function __construct(ConnectionFactory $connectionFactory, QueuesDataBag $queuesDataBag)
+	{
+		$this->queuesDataBag = $queuesDataBag;
+		$this->connectionFactory = $connectionFactory;
+	}
+
+
+	public function declareQueue(string $name): void
+	{
+		try {
+			$queueData = $this->queuesDataBag->getDataBykey($name);
+
+		} catch (\InvalidArgumentException $e) {
+			throw new QueueFactoryException("Queue [$name] does not exist");
+		}
+
+		$connection = $this->connectionFactory->getConnection($queueData['connection']);
+
+		$connection->getChannel()->queueDeclare(
+			$name,
+			$queueData['passive'],
+			$queueData['durable'],
+			$queueData['exclusive'],
+			$queueData['autoDelete'],
+			$queueData['noWait'],
+			$queueData['arguments']
+		);
+	}
+}

--- a/src/Queue/QueueFactory.php
+++ b/src/Queue/QueueFactory.php
@@ -43,10 +43,10 @@ final class QueueFactory
 	/**
 	 * @throws QueueFactoryException
 	 */
-	public function getQueue(string $name): IQueue
+	public function getQueue(string $name, bool $forceDeclare = false): IQueue
 	{
-		if (!isset($this->queues[$name])) {
-			$this->queues[$name] = $this->create($name);
+		if ($forceDeclare || !isset($this->queues[$name])) {
+			$this->queues[$name] = $this->create($name, $forceDeclare);
 		}
 
 		return $this->queues[$name];
@@ -57,20 +57,19 @@ final class QueueFactory
 	 * @throws QueueFactoryException
 	 * @throws ConnectionFactoryException
 	 */
-	private function create(string $name): IQueue
+	private function create(string $name, bool $forceDeclare): IQueue
 	{
 		try {
 			$queueData = $this->queuesDataBag->getDataBykey($name);
 
 		} catch (\InvalidArgumentException $e) {
-
 			throw new QueueFactoryException("Queue [$name] does not exist");
 		}
 
 		// (ConnectionFactoryException)
 		$connection = $this->connectionFactory->getConnection($queueData['connection']);
 
-		if ($queueData['autoCreate']) {
+		if ($forceDeclare || $queueData['autoCreate']) {
 			$connection->getChannel()->queueDeclare(
 				$name,
 				$queueData['passive'],


### PR DESCRIPTION
Added console command to declare all queues and exchanges

Breaking changes:
fixed getDataKeys method name on AbstractDataBag
Queues and Exchanges are no longer auto created by default
