### PR TITLE
hotfix: parameter $secondsToLive was not optional

### DIFF
--- a/src/Console/Command/ConsumerCommand.php
+++ b/src/Console/Command/ConsumerCommand.php
@@ -39,10 +39,6 @@ final class ConsumerCommand extends AbstractConsumerCommand
 			throw new \UnexpectedValueException;
 		}
 
-		if (!is_numeric($secondsToLive) || is_array($secondsToLive)) {
-			throw new \UnexpectedValueException;
-		}
-
 		$this->validateConsumerName($consumerName);
 
 		if ($secondsToLive !== null) {


### PR DESCRIPTION
Commit a82fddb2 introduced optional $secondsToLive, but it was not optional, since check few lines above was throwing for `null`.